### PR TITLE
Add fish completion scripts

### DIFF
--- a/sh/fish/README.md
+++ b/sh/fish/README.md
@@ -1,0 +1,14 @@
+This directory includes fish completions for Tabry
+
+There are two steps to add to your ~/.config/fish/config.fish to use:
+
+1. Source this file
+2. Add a call to `tabry_completion_init`, for each command
+
+```sh
+source tabry_fish.fish
+tabry_completion_init "aws"
+tabry_completion_init "rapture"
+```
+
+Note: Currently, the fish completion support doesn't distinguish between directory completion and file completion.

--- a/sh/fish/tabry_fish.fish
+++ b/sh/fish/tabry_fish.fish
@@ -1,0 +1,95 @@
+
+function tabry_completion_init
+  # Three separate complete calls here are needed to support files.
+  # One provides completions in the case where tabry offers _only_ arguments,
+  # another provides completions where tabry offers _only_ files,
+  # the third handles the case where tabry offers both files and arguments
+  set cmd $argv[1]
+  complete -f -c "$cmd" -n "__fish_tabry_check_only_args" -a "(__fish_tabry_completions)"
+  complete -c "$cmd" -n "__fish_tabry_check_only_file"
+  complete -c "$cmd" -n "__fish_tabry_check_args_and_file" -a "(__fish_tabry_completions)"
+end
+
+# return true if tabry only reports commands
+function __fish_tabry_internal_invoke
+  set SCRIPT (status --current-filename)
+  set SCRIPT_DIR (dirname $SCRIPT)
+
+  # -C "Get cursor position"
+  set cursor_position (commandline -C)
+  set cmd (commandline)
+  set result ($SCRIPT_DIR/../../bin/tabry-bash "$cmd" "$cursor_position")
+  echo $result
+end
+
+# return true if tabry only reports file
+function __fish_tabry_check_only_args
+  set result (__fish_tabry_internal_invoke)
+
+  set args      (echo "$result"|sed 's/  .*//')
+  set specials  (echo "$result"|grep -o '  file')
+
+  # https://github.com/fish-shell/fish-shell/issues/5186#issuecomment-421244106
+  if test "x$args" != "x" -a "$specials" != "  file"
+    # echo "confirming only args:  [$result,$args,$specials]" 1>&2
+    return 0;
+  else
+    # echo "rejecting only args: [$result,$args,$specials]" 1>&2
+    return 1;
+  end
+end
+
+# return true if tabry reports file _and_ commands
+function __fish_tabry_check_only_file
+  set result (__fish_tabry_internal_invoke)
+
+  set args      (echo "$result"|sed 's/  .*//')
+
+  if test "x$args" = "x" -a (string match -ra '  file' $result)
+    # echo "confirming only file" 1>&2
+    return 0;
+  else
+    # echo "rejecting only file: [$args,$specials]" 1>&2
+    return 1;
+  end
+end
+
+function __fish_tabry_check_args_and_file
+  set result (__fish_tabry_internal_invoke)
+
+  set args      (echo "$result"|sed 's/  .*//')
+
+  if test "x$args" != "x" -a (string match -ra '  file' $result)
+    # echo "confirming args and file" 1>&2
+    return 0;
+  else
+    # echo "rejecting args and file: [$args,$specials]" 1>&2
+    return 1;
+  end
+end
+
+function __fish_tabry_completions
+  set result (__fish_tabry_internal_invoke)
+
+  set args      (echo "$result"|sed 's/  .*//')
+
+  set args_parsed (string split ' ' $args)
+
+  if test "x$args" = "x"
+    # Don't offer anything if we don't have any completions
+    return 1;
+  else
+    # $args_parsed will be something like: ["foo" "bar" "baz" "" "file"]
+    #   where "file" is special, since it's after the space.
+    for arg in $args_parsed
+      if test "x$arg" != "x"
+        echo "$arg"
+      else
+        break;
+      end
+    end
+
+    # echo $args
+    return 0;
+  end
+end


### PR DESCRIPTION
This commit adds fish completion scripts. As stated in the documentation, It currently doesn't distinguish between file completions and directory completions. The native fish `complete` command doesn't seem to support it (https://fishshell.com/docs/current/completions.html), so something custom would have to be written.