### PR TITLE
Restructuring the tabryc derivation and flakes app

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,21 +186,21 @@ nix run github:evanbattaglia/tabry#tabryc path/to/file.tabry path/to/file.json
 
 This flake provides a home-manager (https://github.com/nix-community/home-manager) module to make it easy to configure and use tabry completions.
 
-You can use this module by adding this to your home-manager configuration:
+You can add autocompletion to your shell by adding this module to your home-manager configuration, and configuring it:
 
 ```nix
 {
   inputs = {
-    ...
+    # ...
     tabry.url = "github:evanbattaglia/tabry";
   };
-  
-  ...
-  home-manager.lib.homeManagerConfiguration {
-    ...
+
+  # ...
+  homeConfigurations.base = home-manager.lib.homeManagerConfiguration {
+    # ...
     modules = [
-      tabry.homeModules.tabry,
-      ...
+      tabry.homeModules.tabry
+      # ...
       {
         config.programs.tabry = {
           enable = true;
@@ -210,8 +210,27 @@ You can use this module by adding this to your home-manager configuration:
           ];
         };
       }
-    ]
-  }
+    ];
+  };
+}
+```
+
+You can also install the `tabryc` compiler using the `tabryc` package:
+
+```nix
+{
+  inputs = {
+    # ...
+    tabry.url = "github:evanbattaglia/tabry";
+  };
+
+  # ...
+  homeConfigurations.base = home-manager.lib.homeManagerConfiguration {
+    # ...
+    config.home.packages = [
+      tabry.packages.${system}.tabryc
+    ];
+  };
 }
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,10 +20,10 @@
             packages = {
               default = tabry;
               tabry = tabry;
-              treesitterTabryBuild = tabryLang.treesitterTabryBuild;
+              tabryc = tabryLang.tabryc;
             };
             apps = {
-              tabryc = tabryLang.tabryc;
+              tabryc = tabryLang.tabrycApp;
             };
           }
       ) // {

--- a/nix/tabry-hm-module.nix
+++ b/nix/tabry-hm-module.nix
@@ -39,7 +39,7 @@ in {
 
     programs.fish.shellInit = mkIf cfg.enableFishIntegration (
       let 
-        tabryImportsPath = builtins.concatStringsSep " " (compileTabryFiles cfg.tabryFiles);
+        tabryImportsPath = builtins.concatStringsSep ":" (compileTabryFiles cfg.tabryFiles);
       in ''
         set -x TABRY_IMPORTS_PATH "${builtins.trace tabryImportsPath tabryImportsPath}:$TABRY_IMPORTS_PATH"
         source ${tabry}/sh/fish/tabry_fish.fish


### PR DESCRIPTION
This commit does a few things:

1. Renames `treesitterTabryBuild` ~> `tabryc` and renames the app `tabryc` ~> `tabrycApp` (`tabrycApp` is still offered at `outputs.apps.${system}.tabryc` as to enable `nix run .#tabryc -- ...`)
2. Adds a `bin/tabryc` wrapper script to `tabryc`, as to make it an installable package which exposes `tabryc` on the PATH
3. Updates the `README.md` file with examples and fixes some formatting