### PR TITLE
Add withTabry helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,31 @@ You can also install the `tabryc` compiler using the `tabryc` package:
 }
 ```
 
+
+## Packaging nix derivations with tabry completions
+
+You can wrap a nix package with tabry completions using the `withTabry` helper function.
+
+```nix
+{
+  foo = withTabry ./foo.tabry (
+    pkgs.writeScriptBin "foo" ''
+      echo "$1";
+    ''
+  );
+}
+```
+
+where ./foo.tabry is a normal tabry file:
+
+```
+cmd foo
+
+sub foo
+sub bar
+sub baz
+```
+
 # Future possible improvements
 * `mycmd -ab` should be interpreted as `mycmd -a -b`
 * if subcommand allows flag "-a", maybe allow it before the subcommand -- e.g. `mycmd -a mysub`

--- a/flake.nix
+++ b/flake.nix
@@ -8,22 +8,27 @@
 
   outputs = { self, nixpkgs, flake-utils, ... }:
     let
-      tabryHmModule = import ./nix/tabry-hm-module.nix flake-utils;
+      tabryHmModule = import ./nix/tabry-hm-module.nix;
     in
       flake-utils.lib.eachDefaultSystem (
         system:
           let
             pkgs = nixpkgs.legacyPackages."${system}";
-            tabry = import ./default.nix pkgs;
-            tabryLang = import ./treesitter flake-utils pkgs;
+            tabry = pkgs.callPackage ./default.nix {};
+            tabryLang = pkgs.callPackage ./treesitter {};
+            withTabry = pkgs.callPackage ./nix/withTabry.nix {};
           in {
             packages = {
               default = tabry;
               tabry = tabry;
               tabryc = tabryLang.tabryc;
             };
+            inherit withTabry;
             apps = {
-              tabryc = tabryLang.tabrycApp;
+              tabryc = flake-utils.lib.mkApp {
+                drv = tabryLang.tabryc;
+                name = "tabryc";
+              };
             };
           }
       ) // {

--- a/nix/tabry-hm-module.nix
+++ b/nix/tabry-hm-module.nix
@@ -1,4 +1,4 @@
-flake-utils: { config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -6,8 +6,8 @@ let
 
   cfg = config.programs.tabry;
 
-  tabry = import ../default.nix pkgs;
-  tabryLang = import ../treesitter flake-utils pkgs;
+  tabry = lib.callPackage ../default.nix {};
+  tabryLang = lib.callPackage ../treesitter {};
 
   mkInitFish = fileName: let
     commandName = tabryLang.commandNameFromTabryFilename fileName;

--- a/nix/withTabry.nix
+++ b/nix/withTabry.nix
@@ -1,0 +1,23 @@
+{lib, callPackage, stdenv, installShellFiles, ruby}:
+let 
+  tabry = callPackage ../default.nix {};
+  tabryLang = callPackage ../treesitter {};
+in
+  tabryFile: package: 
+    let
+      cmd = builtins.replaceStrings [".tabry"] [""] (builtins.baseNameOf tabryFile);
+    in stdenv.mkDerivation {
+      name = "${package.name}-with-tabry";
+      nativeBuildInputs = [ installShellFiles ];
+      src = ./.;
+      installPhase = ''
+        mkdir -p $out/bin
+        cp -R ${package}/bin $out/
+
+        ${tabry}/bin/tabry-generate-bash-complete ${cmd} \
+          ${tabryLang.compileTabryFile tabryFile}/${cmd}.json \
+          -r ${ruby}/bin/ruby --uniq-fn-id NIX_${lib.toUpper package.name} >> ${cmd}.bash
+
+        installShellCompletion ${cmd}.bash
+      '';
+    }

--- a/treesitter/default.nix
+++ b/treesitter/default.nix
@@ -1,4 +1,4 @@
-flake-utils: {
+{
   mkYarnPackage,
   python3,
   stdenv,
@@ -6,7 +6,7 @@ flake-utils: {
   xcbuild,
   nodejs-16_x,
   ...
-} @pkgs:
+}:
 
   let
     # treesitter doesn't work with node 17/18
@@ -67,11 +67,6 @@ flake-utils: {
       '';
     };
 
-    tabrycApp = flake-utils.lib.mkApp {
-      drv = tabryc;
-      name = "tabryc";
-    };
-
   in {
-    inherit tabryc compileTabryFile tabrycApp commandNameFromTabryFilename;
+    inherit tabryc compileTabryFile commandNameFromTabryFilename;
   }


### PR DESCRIPTION
This commit adds a withTabry helper, which aims to wrap another package along with a tabry file providing completions for that package.

Use like:

```nix
{
  foo = withTabry ./foo.tabry (
    pkgs.writeScriptBin "foo" ''
      echo "$1";
    ''
  );
}
```

where `./foo.tabry` is a normal tabry file:

```
cmd foo

sub foo
sub bar
sub baz
```