### PR TITLE
Fixing errors on fish completion for flags

### DIFF
--- a/sh/fish/tabry_fish.fish
+++ b/sh/fish/tabry_fish.fish
@@ -29,7 +29,7 @@ function __fish_tabry_check_only_args
   set args      (echo "$result"|sed 's/  .*//')
   set specials  (echo "$result"|grep -o '  file')
 
-  # https://github.com/fish-shell/fish-shell/issues/5186#issuecomment-421244106
+  # https://github.com/fish-shell/fish-shell/issues/5186#issuecomment-421244106 (the random "x")
   if test "x$args" != "x" -a "$specials" != "  file"
     # echo "confirming only args:  [$result,$args,$specials]" 1>&2
     return 0;
@@ -45,7 +45,8 @@ function __fish_tabry_check_only_file
 
   set args      (echo "$result"|sed 's/  .*//')
 
-  if test "x$args" = "x" -a (string match -ra '  file' $result)
+  # The '--' arg is needed in case $result contains flag-like strings
+  if test "x$args" = "x" -a (string match -ra -- '  file' $result)
     # echo "confirming only file" 1>&2
     return 0;
   else
@@ -59,7 +60,8 @@ function __fish_tabry_check_args_and_file
 
   set args      (echo "$result"|sed 's/  .*//')
 
-  if test "x$args" != "x" -a (string match -ra '  file' $result)
+  # The '--' arg is needed in case $result contains flag-like strings
+  if test "x$args" != "x" -a (string match -ra -- '  file' $result)
     # echo "confirming args and file" 1>&2
     return 0;
   else
@@ -73,7 +75,8 @@ function __fish_tabry_completions
 
   set args      (echo "$result"|sed 's/  .*//')
 
-  set args_parsed (string split ' ' $args)
+  # The '--' arg is needed in case $result contains flag-like strings
+  set args_parsed (string split -- ' ' $args)
 
   if test "x$args" = "x"
     # Don't offer anything if we don't have any completions


### PR DESCRIPTION
When tabry provided completions for flags, the fish script did not "escape" them properly when passing them to further string manipulations i.e. When tabry provided "--foo --bar" as completions, the tabry fish file used them like so (to test if tabry provides file completions):

```
string match -ra '  file' "--foo --bar"
```

This fails with an error like:
```
string match: --foo: unknown option

/nix/store/388nirk31rgs6fp1b9aa2h4hvniv7fy7-tabry/sh/fish/tabry_fish.fish
(line 1):
in command substitution
	called on line 48 of file
/nix/store/388nirk31rgs6fp1b9aa2h4hvniv7fy7-tabry/sh/fish/tabry_fish.fish
in function '__fish_tabry_check_only_file'
in command substitution

(Type 'help string' for related documentation)
```

The fix is to add "--" after the real options are passed.

> To match things that look like options ... , we need a `--`
> to tell string its options end there"

https://fishshell.com/docs/current/cmds/string-match.html